### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all
+    @items = Item.order(created_at: :desc)
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,7 @@ class Item < ApplicationRecord
   belongs_to :shipping_day
 
   belongs_to :user
+  has_one :record
   has_one_attached :image
 
   validates :item_name, presence: true, length: { maximum: 40 }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   belongs_to :shipping_day
 
   belongs_to :user
-  has_one :record
+  # has_one :record
   has_one_attached :image
 
   validates :item_name, presence: true, length: { maximum: 40 }

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,0 +1,4 @@
+class Record < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,4 +1,4 @@
 class Record < ApplicationRecord
-  belongs_to :user
-  belongs_to :item
+  # belongs_to :user
+  # belongs_to :item
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
-  has_many :records
+  # has_many :records
 
   validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'には英字と数字の両方を含めて設定してください' }
   validates :first_name, presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'は全角文字で入力してください' }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
+  has_many :records
 
   validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'には英字と数字の両方を含めて設定してください' }
   validates :first_name, presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'は全角文字で入力してください' }

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,18 +128,19 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% if @items.any? %>
       <% @items.each do |item| %> 
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag item.image.attached? ? item.image : "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# Sold Outの表記
+          <%# <% if item.record.present? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <%# <% end %>
 
         </div>
         <div class='item-info'>
@@ -157,10 +158,8 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -178,8 +177,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,10 +129,11 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %> 
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image.attached? ? item.image : "item-sample.png", class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,10 +144,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_cost_burden.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,6 +156,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>

--- a/db/migrate/20250223131620_create_records.rb
+++ b/db/migrate/20250223131620_create_records.rb
@@ -1,0 +1,9 @@
+class CreateRecords < ActiveRecord::Migration[7.1]
+  def change
+    create_table :records do |t|
+      t.references :user,null: false, foreign_key: true
+      t.references :item,null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250223131620_create_records.rb
+++ b/db/migrate/20250223131620_create_records.rb
@@ -1,8 +1,8 @@
 class CreateRecords < ActiveRecord::Migration[7.1]
   def change
     create_table :records do |t|
-      t.references :user,null: false, foreign_key: true
-      t.references :item,null: false, foreign_key: true
+      # t.references :user,null: false, foreign_key: true
+      # t.references :item,null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_15_122329) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_23_131620) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -54,6 +54,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_15_122329) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "records", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_records_on_item_id"
+    t.index ["user_id"], name: "index_records_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb3", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -75,4 +84,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_15_122329) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "records", "items"
+  add_foreign_key "records", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,12 +55,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_23_131620) do
   end
 
   create_table "records", charset: "utf8mb3", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["item_id"], name: "index_records_on_item_id"
-    t.index ["user_id"], name: "index_records_on_user_id"
   end
 
   create_table "users", charset: "utf8mb3", force: :cascade do |t|
@@ -84,6 +80,4 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_23_131620) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
-  add_foreign_key "records", "items"
-  add_foreign_key "records", "users"
 end

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :record do
+    
+  end
+end

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :record do
-    
   end
 end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Record, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
- トップページに出品された商品を一覧表示できるように実装
- 商品は出品された日時が新しい順に並ぶように設定
- 商品が出品されていない場合は、ダミー商品を表示するように設定

# Why
- ユーザーが出品された商品を確認できるようにするため
- 新しく出品された商品がすぐにわかるようにするため


商品のデータがない場合は、ダミー商品が表示されている動画
[https://gyazo.com/8a7943923c3fd121b172cf9769de8b0c](url)

商品のデータがある場合は、商品が一覧で表示されている動画
[https://gyazo.com/7fcaab2a42a2d0324fcb3e202781b5f4](url)
